### PR TITLE
Add create_ssl raketask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .rake_test_cache
+.ssl/
+!.ssl/openssl.cnf
 
 ###
 # Ignore Chef key files and secrets

--- a/.ssl/openssl.cnf
+++ b/.ssl/openssl.cnf
@@ -1,0 +1,53 @@
+[ ca ]
+default_ca = sensu_ca
+
+[ sensu_ca ]
+dir = .
+certificate = $dir/ca/ca-cert.pem
+database = $dir/index.txt
+new_certs_dir = $dir/certs
+private_key = $dir/ca/ca-key.pem
+serial = $dir/serial
+
+default_crl_days = 7
+default_days = 1825
+default_md = sha1
+
+policy = sensu_ca_policy
+x509_extensions = certificate_extensions
+
+[ sensu_ca_policy ]
+commonName = supplied
+stateOrProvinceName = optional
+countryName = optional
+emailAddress = optional
+organizationName = optional
+organizationalUnitName = optional
+
+[ certificate_extensions ]
+basicConstraints = CA:false
+
+[ req ]
+default_bits = 2048
+default_keyfile = ./ca/ca-key.pem
+default_md = sha1
+prompt = yes
+distinguished_name = root_ca_distinguished_name
+x509_extensions = root_ca_extensions
+
+[ root_ca_distinguished_name ]
+commonName = sensu
+
+[ root_ca_extensions ]
+basicConstraints = CA:true
+keyUsage = keyCertSign, cRLSign
+
+[ client_ca_extensions ]
+basicConstraints = CA:false
+keyUsage = digitalSignature
+extendedKeyUsage = 1.3.6.1.5.5.7.3.2
+
+[ server_ca_extensions ]
+basicConstraints = CA:false
+keyUsage = keyEncipherment
+extendedKeyUsage = 1.3.6.1.5.5.7.3.1

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,58 @@ task :push_latest_release do
   # no-op
 end
 
+task :create_ssl do
+  ssl_directory = ".ssl"
+  cert_name = "sensu-rabbitmq"
+
+  %w[ca client server certs].each do |sub_directory|
+    FileUtils.mkdir_p(File.join(ssl_directory, sub_directory))
+  end
+
+  ssl_files = {
+    :index => "index.txt",
+    :serial => "serial",
+    :ca_key => File.join("ca", "ca-key.pem"),
+    :ca_cert => File.join("ca", "ca-cert.pem"),
+    :ca_csr => File.join("ca", "ca.cer"),
+    :client_cert => File.join("client", "#{cert_name}-cert.pem"),
+    :client_key => File.join("client", "#{cert_name}-key.pem"),
+    :client_csr => File.join("client", "#{cert_name}-csr.pem"),
+    :server_cert => File.join("server", "#{cert_name}-cert.pem"),
+    :server_key => File.join("server", "#{cert_name}-key.pem"),
+    :server_csr => File.join("server", "#{cert_name}-csr.pem"),
+  }
+
+  Dir.chdir(ssl_directory) do
+    FileUtils.touch(ssl_files[:index]) unless File.exists?(ssl_files[:index])
+
+    unless File.exists?(ssl_files[:serial])
+      File.open(ssl_files[:serial], "w") do |file|
+        file.write("01")
+      end
+    end
+
+    # generate a new self-signed CA key & certificate
+    unless File.exists?(ssl_files[:ca_key]) && File.exists?(ssl_files[:ca_cert])
+      system("openssl req -x509 -config openssl.cnf -days 1825 -subj /CN=SensuCA/ -nodes -newkey rsa:2048 -keyout #{ssl_files[:ca_key]} -out #{ssl_files[:ca_cert]}")
+    end
+
+    # generate server key & certificate
+    unless File.exists?(ssl_files[:server_key]) && File.exists?(ssl_files[:server_cert])
+      system("openssl genrsa -out #{ssl_files[:server_key]} 2048")
+      system("openssl req -new -key #{ssl_files[:server_key]} -out #{ssl_files[:server_csr]} -subj /CN=sensu/O=server/ -nodes")
+      system("openssl ca -config openssl.cnf -in #{ssl_files[:server_csr]} -out #{ssl_files[:server_cert]} -notext -batch -extensions server_ca_extensions")
+    end
+
+    # generate client key & certificate
+    unless File.exists?(ssl_files[:client_key]) && File.exists?(ssl_files[:client_cert])
+      system("openssl genrsa -out #{ssl_files[:client_key]} 2048")
+      system("openssl req -new -key #{ssl_files[:client_key]} -out #{ssl_files[:client_csr]} -subj /CN=sensu/O=client/ -nodes")
+      system("openssl ca -config openssl.cnf -in #{ssl_files[:client_csr]} -out #{ssl_files[:client_cert]} -notext -batch -extensions client_ca_extensions")
+    end
+  end
+end
+
 task :publish => [:create_release, :push_latest_release]
 
 task :default => :create_release


### PR DESCRIPTION
Adds a raketask that can generate SSL keys & certs for CA, server & client (to be used by RabbitMQ & Sensu).
